### PR TITLE
[fix] API명세서랑 변수명 틀린부분 수정

### DIFF
--- a/src/main/java/com/example/taskflow/domain/common/dto/PagedResponse.java
+++ b/src/main/java/com/example/taskflow/domain/common/dto/PagedResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
  * @param <T> 페이지에 담길 개별 요소 타입
  */
 public record PagedResponse<T> (
-        List<T> content,       // 현재 페이지에 포함된 데이터 리스트
+        List<T> contents,       // 현재 페이지에 포함된 데이터 리스트
         int page,              // 현재 페이지 번호 (0부터 시작)
         int size,              // 페이지당 항목 수
         int totalPages,        // 전체 페이지 수

--- a/src/main/java/com/example/taskflow/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/example/taskflow/domain/common/entity/BaseEntity.java
@@ -21,5 +21,5 @@ public abstract class BaseEntity {
     @LastModifiedDate
     @Column
     @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime modifiedAt;
+    private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
페이지 반환값이 API 명세서와 매치되지않아 수정하였습니다
베이스엔티티 또한 수정일 변수명이 틀려 수정하였습니다 확인부탁드립니다.